### PR TITLE
Make Troubleshoot Error Messages Visible

### DIFF
--- a/docs/windows_install.rst
+++ b/docs/windows_install.rst
@@ -145,17 +145,17 @@ Troubleshooting Windows Install
 
 If you run into either of the following errors when trying to install a Linux distribution: 
 
-.. code-block::
+.. code-block:: powershell
 
   Installing, this may take a few minutes...
   WslRegisterDistribution failed with error: 0x80370102
   Error: 0x80370102 The virtual machine could not be started 
-      because a required feature is not installed. 
+    because a required feature is not installed. 
   
 or when trying to run the Docker Desktop GUI: 
   
-.. code-block::
-
+  
+.. code-block:: powershell  
   Hardware assisted virtualization and data execution protection
   must be enabled in BIOS.  
   

--- a/docs/windows_install.rst
+++ b/docs/windows_install.rst
@@ -145,17 +145,13 @@ Troubleshooting Windows Install
 
 If you run into either of the following errors when trying to install a Linux distribution: 
 
-.. code-block:: powershell
-
   Installing, this may take a few minutes...
   WslRegisterDistribution failed with error: 0x80370102
   Error: 0x80370102 The virtual machine could not be started 
-    because a required feature is not installed. 
+  because a required feature is not installed. 
   
 or when trying to run the Docker Desktop GUI: 
-  
-  
-.. code-block:: powershell  
+
   Hardware assisted virtualization and data execution protection
   must be enabled in BIOS.  
   


### PR DESCRIPTION
## Description

The two error messages in the Troubleshooting Windows Install were not visible because the 'powershell' keyword wasn't placed next to the code-block. I removed the code-block to make the error message visible.

## Motivation and Context

Fixes the problem of the error messages not showing up.
